### PR TITLE
fixes inventory name in command

### DIFF
--- a/.github/workflows/ansible-default.yml
+++ b/.github/workflows/ansible-default.yml
@@ -57,7 +57,7 @@ jobs:
           
           cd ansible
           mkdir logs
-          ansible-playbook --inventory=inventory.yml site.yml \
+          ansible-playbook --inventory=inventory.vmware.yml site.yml \
                            --vault-password-file=ansible-vault-password-file.txt \
                            --user=ansible-deploy \
                            --private-key=ansible-ssh-private-key \


### PR DESCRIPTION
this could also be addressed by renaming the file /ansible/inventory.vmware.yml to /ansible/inventory.yml